### PR TITLE
hotfix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,10 +6,11 @@ on:
             - closed
         branches:
             - "master"
+    workflow_dispatch:
 
 jobs:
     deploy:
-        if: github.event.pull_request.merged == true
+        if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
         name: Deploy
         permissions:


### PR DESCRIPTION
This pull request includes a small but significant change to the GitHub Actions workflow configuration in the `.github/workflows/deploy.yml` file. The change allows the deployment job to be triggered manually via the `workflow_dispatch` event in addition to being triggered automatically when a pull request is merged.

Changes to deployment trigger:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R9-R13): Added support for `workflow_dispatch` to manually trigger the deployment job. Updated the condition to include `github.event_name == 'workflow_dispatch'`.