### PR TITLE
Update information about Osaka City University Aikido Club activities from 1968 to 2018

### DIFF
--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -24,24 +24,9 @@ import { default as Layout } from "@/src/pages-layouts/static-layout.astro";
             </ul>
         </li>
         <li>
-            1968年
-            <ul>
-                <li>大阪市立大学合氣道部: 発足</li>
-            </ul>
-        </li>
-        <li>
-            2018年 4月
-            <ul>
-                <li>大阪市立大学合氣道部: 廃部</li>
-            </ul>
-        </li>
-        <li>
             2018年 10月
             <ul>
-                <li>
-                    大阪市立大学合氣道サークル:
-                    市大合氣道部の活動を引き継ぐ形で発足
-                </li>
+                <li>大阪市立大学合氣道サークル: 発足</li>
             </ul>
         </li>
         <li>
@@ -55,6 +40,11 @@ import { default as Layout } from "@/src/pages-layouts/static-layout.astro";
         </li>
         現在に至る
     </ul>
+
+    <p>
+        1968年から2018年４月まで、天之武産合氣塾道場門下の大阪市立大学体育会合氣道部が活動していました。
+        別団体ではありますが、旧三商大合同稽古などのイベントを受け継いでいます。
+    </p>
     <hr />
     <h1 class="block-color-blue_background">活動場所</h1>
     <p>大阪公立大学の以下施設にて活動しています。</p>


### PR DESCRIPTION
Revise the description of the club's activities and organize list items for clarity. Add a summary of the club's history during the specified years.